### PR TITLE
Added cellStyles prop to MonthViewCalendar

### DIFF
--- a/lib/components/calendarDay.js
+++ b/lib/components/calendarDay.js
@@ -26,8 +26,8 @@ var CalendarDay = /** @class */ (function (_super) {
         return _super !== null && _super.apply(this, arguments) || this;
     }
     CalendarDay.prototype.render = function () {
-        var _a = this.props, index = _a.index, date = _a.date, renderEvent = _a.renderEvent, events = _a.events, textStyles = _a.textStyles;
-        var cellStyles = [styles.cell];
+        var _a = this.props, index = _a.index, date = _a.date, renderEvent = _a.renderEvent, events = _a.events, textStyles = _a.textStyles, cStyles = _a.cStyles;
+        var cellStyles = [styles.cell, cStyles];
         if (index === 0) {
             cellStyles.push(styles.leftBorder);
         }
@@ -38,14 +38,14 @@ var CalendarDay = /** @class */ (function (_super) {
     return CalendarDay;
 }(react_1.default.Component));
 CalendarDay.defaultProps = {
-    textStyles: {},
+  textStyles: {},
+  cStyles: {},
 };
 var styles = react_native_1.StyleSheet.create({
     cell: {
         width: '14.2857142857%',
-        borderColor: '#CCCCCC',
+        borderColor: 'rgba(0,0,0,.1)',
         borderRightWidth: 1,
-        minHeight: 65,
         paddingTop: 3,
         paddingHorizontal: 1.5,
     },

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,7 +6,8 @@ interface MonthViewProps {
     weekDays: string[];
     events: Event[];
     headerTextStyles: any;
-    dayTextStyles?: any;
+  dayTextStyles?: any;
+  cellStyles?: any;
     renderEvent: (event: Event, index: number) => any;
     onSwipe?: (date: Date) => void;
     onSwipePrev?: (date: Date) => void;
@@ -26,7 +27,8 @@ declare class MonthViewCalendar extends React.Component<MonthViewProps, MonthVie
         date: Date;
         weekDays: string[];
         headerTextStyles: {};
-        dayTextStyles: {};
+      dayTextStyles: {};
+      cellStyles: {};
     };
     state: MonthViewState;
     pageOffset: number;

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,6 +82,7 @@ var MonthViewCalendar = /** @class */ (function (_super) {
         _this.getCurrentDate = function () {
             return _this.state.datesList[_this.currentPageIndex];
         };
+      
         /**
          * Change month that is being shown
          */
@@ -181,7 +182,7 @@ var MonthViewCalendar = /** @class */ (function (_super) {
         var days = (0, utils_1.getDaysOfCalendarMonth)(date);
         return days.map(function (week, i) { return (react_1.default.createElement(calendarRow_1.default, { key: "week-".concat(i) }, week.map(function (day, j) {
             var eventsOfDay = (0, utils_1.findEventsForTheDay)(day, _this.props.events);
-            return (react_1.default.createElement(calendarDay_1.default, { key: j, index: j, date: day, events: eventsOfDay, renderEvent: _this.props.renderEvent, textStyles: _this.props.dayTextStyles }));
+            return (react_1.default.createElement(calendarDay_1.default, { key: j, index: j, date: day, events: eventsOfDay, renderEvent: _this.props.renderEvent, textStyles: _this.props.dayTextStyles, cStyles: _this.props.cellStyles }));
         }))); });
     };
     MonthViewCalendar.prototype.render = function () {
@@ -209,7 +210,8 @@ MonthViewCalendar.defaultProps = {
     date: new Date(),
     weekDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
     headerTextStyles: {},
-    dayTextStyles: {},
+  dayTextStyles: {},
+  cellStyles: {}
 };
 var styles = react_native_1.StyleSheet.create({
     calendarContainer: {


### PR DESCRIPTION
I wanted to increase the height of the cells, but currently you can only do that with content inside each cell.  Editing cellStyles allows you to change the styles of every cell, including minHeight.

Right now, this packaged is patched in my project to include this feature, but I hope you accept this pull request so that others can take advantage of this.